### PR TITLE
Make ReactConnector.d.ts work with recent @typings/react

### DIFF
--- a/typings/ReactConnector.d.ts
+++ b/typings/ReactConnector.d.ts
@@ -1,5 +1,4 @@
-
-import React = __React;
+import * as React from 'react';
 import { Store as StoreInstance } from './fluxx';
 
 


### PR DESCRIPTION
Recent `@typings/react` no longer export the `__React` namespace. Note that this change also work with older typings (e.g. `0.14`).